### PR TITLE
parallelize getseq from python

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,9 @@ By default, getseq will raise an Exception if it is unable to return a sequence 
 
 ## Changes
 
+### V2.1 (March 2024)
+* Added parallelization for queries h/t jeff
+
 ### V2.0 (February 2024)
 * Major update to command-line and Python functionality
 * Added ability to do multiple queries from a single command from CLI

--- a/getSequence/__init__.py
+++ b/getSequence/__init__.py
@@ -1,7 +1,7 @@
 """A CLI to get a uniprot sequence returned to terminal"""
 
 # Add imports here
-from .getseq import getseq as getseq
+from .getseq import getseq, batch_getseq
 
 # Handle versioneer
 from ._version import get_versions


### PR DESCRIPTION
## Description
Process getseq queries in parallel from python using functools and multiprocessing.

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [x] Parallelize `getseq` via a `batch_getseq` function that accepts all `kwargs` of `getseq`
  - [ ] You could add to this for the CLI tooling you implement!

## Status
- [x] Ready to go